### PR TITLE
Updated Get-ComputerAudit.ps1

### DIFF
--- a/Get-ComputerAudit.ps1
+++ b/Get-ComputerAudit.ps1
@@ -49,7 +49,7 @@ Function Get-ComputerAudit
             If ( -not (Test-Connection $Computer -Quiet -Count 1) )
             {
 
-                Write-Error "Cannot connect to target '$Computer'."
+                Write-Error -Message "Unable to connect to target '$Computer'." -Exception ([System.TimeoutException]::new()) -Category ConnectionError -CategoryTargetName $Computer
                 Continue
                 
             }


### PR DESCRIPTION
closes #16
Cannot connect error now uses System.TimeoutException, instead of default Write-Error exception
The same error also now has a category of ConnectionError