### PR TITLE
Updated Get-ComputerWsusAudit.ps1

### DIFF
--- a/Get-ComputerWsusAudit.ps1
+++ b/Get-ComputerWsusAudit.ps1
@@ -1,6 +1,46 @@
-﻿Function Get-ComputerWsusAudit
+﻿<#
+.Synopsis
+   Get Windows Update information from a local WSUS server.
+.DESCRIPTION
+   Connects to the WSUS server. Will return an object listing all the update states for the computer and a count of how many updates are in each state for the computer.
+.PARAMETER ComputerName
+   The "FullDomainName" of a computer.
+   If joined to a domain, this would be a FQDN (Fully Qualified Domain Name), if in a workgroup then just the computer name should be included without the workgroup name.
+.PARAMETER UpdateClassification
+   The title of an Update Classification. The values input into this parameter are checked against the list of classifications on the update server specified.
+   See notes for an example list and further details.
+.EXAMPLE
+    This will return information about all Critical and Security updates for 'computer1' joined to domain 'mccabeshell.com'.
+    Get-ComputerWsusAudit 'computer1.mccabeshell.com' -UpdateClassification 'Critical Updates','Security Updates' -UpdateServer 'WSUSSERVER' -PortNumber '8530'
+.EXAMPLE
+    This will return information about all Critical and Security updates for computer computer1 if it is in a Workgroup. If it was joined to a domain then an Object not found error would be thrown.
+    Get-ComputerWsusAudit 'computer1' -UpdateClassification 'Critical Updates','Security Updates' -UpdateServer 'WSUSSERVER' -PortNumber '8530'
+.NOTES
+   List of Update Classifications. It is possible that these classifications may vary with different versions of WSUS and over time.
+
+   Applications
+   Critical Updates
+   Definition Updates
+   Drivers
+   Feature Packs
+   Security Updates
+   Service Packs
+   Tools
+   Update Rollups
+   Updates
+   Upgrades
+
+   Due to the fact you need to know the exact title, a new cmdlet may be added to the PSComputerAudit repository to get UpdateClassifications.
+   This function already does this to get the list to compare to. It uses the method GetUpdateClassifications, returning objects of "Microsoft.UpdateServices.Internal.BaseApi.UpdateClassification".
+   See link for more details about this method.
+.LINK
+    https://msdn.microsoft.com/en-us/library/windows/desktop/ms747071(v=vs.85).aspx
+#>
+
+Function Get-ComputerWsusAudit
 {
 
+    [CmdletBinding()]
     Param
     (
 
@@ -11,7 +51,9 @@
         [ValidateNotNullOrEmpty()]
         [string[]]$ComputerName,
 
-        [string[]]$UpdateClassification = $null,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$UpdateClassification,
 
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
Fixes #15
UpdateClassification is now a required parameter.
Added comment-based help, including information about the parameter UpdateClassification and FQDN gotcha of ComputerName.